### PR TITLE
chore / Improves logo loading time

### DIFF
--- a/src/components/logo.js
+++ b/src/components/logo.js
@@ -19,8 +19,8 @@ const Logo = () => (
       query {
         placeholderImage: file(relativePath: { eq: "logo-white.png" }) {
           childImageSharp {
-            fluid(maxWidth: 800) {
-              ...GatsbyImageSharpFluid
+            fluid(maxWidth: 400) {
+              ...GatsbyImageSharpFluid_tracedSVG
             }
           }
         }


### PR DESCRIPTION
I used svg trace for placeholder and reduced the size of the image by half